### PR TITLE
Improve checking of tags, provide better error message

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -1,27 +1,47 @@
 #!/bin/bash
 
-# fail if any command fails
+# Fail if any command fails
 set -e
 
-latest_tag=`git describe --tags`
-previous_tag="$(git describe --abbrev=0 --tags $(git rev-list --tags --skip=1 --max-count=1))"
+# Read all tags, separate them into an array
+IFS='\n' read -r -a all_tags <<< "`git tag -l`"
+
+if [ ${#all_tags[@]} = 0 ]; then
+    # No tags, exit.
+    echo "Reposiotry contains no tags. Please make a tag first."
+    exit 1
+elif [ ${#all_tags[@]} = 1 ]; then
+    # We have first tag, fetch since first commit (ie. don't specify previous tag)
+    latest_tag=`git describe --tags`
+else 
+    # We have many tags, fetch since last one
+    latest_tag=`git describe --tags`
+    previous_tag="$(git describe --abbrev=0 --tags $(git rev-list --tags --skip=1 --max-count=1))"
+fi
+
 changelog="Empty changelog"
-committer="Build triggered from: $(git log --pretty=format:"%ce" HEAD^..HEAD)"
 
 if [[ ! -z "$previous_tag" ]] && [[ ! -z "$latest_tag" ]] ; then
+    # Get commit messages since previous tag
     changelog="$(git log --pretty=format:" - %s (%ce - %cD)" $latest_tag...$previous_tag)"    
+
 elif [[ ! -z "$latest_tag" ]] ; then
+    # Get commit messages since first commit
     changelog="$(git log --pretty=format:" - %s (%ce - %cD)")"
+
 else
+    # This should never happen, but who knows? ¯\_(ツ)_/¯
     echo "No latest tag specified!"
     exit 1
 fi
 
-echo "Committer: $committer"
+# Output colledcted information
+echo "Committer: $(git log --pretty=format:"%ce" HEAD^..HEAD)"
 echo "Latest tag: $latest_tag"
 echo "Previous tag: $previous_tag"
 echo "Changelog: $changelog"
 
+# Set environment variable for bitrise
 envman add --key COMMIT_CHANGELOG --value "$changelog"
 
 exit 0


### PR DESCRIPTION
Contains following changes:

- [x] Fails if no tags specified
- [x] If only one tag specified, fetches changelog to the first commit
- [x] Comments, general niceness

Fixes #4.