### PR TITLE
is_always_run: false

### DIFF
--- a/step.yml
+++ b/step.yml
@@ -11,7 +11,7 @@ project_type_tags: []
 type_tags:
   - utility
 is_requires_admin_user: false
-is_always_run: true
+is_always_run: false
 is_skippable: false
 deps:
   brew:


### PR DESCRIPTION
Is there any reason to mark this step by default with `is_always_run: true`? Users can set it to `true` if they want to, default should be kept on `false` (no point in running this step if a previous one failed *by default*)