### PR TITLE
Allow customizing git log format

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -6,12 +6,6 @@ set -e
 # Read all tags, separate them into an array
 all_tags=`git tag -l | wc -l`
 
-if [ -n "${markdown_output}" -a "${markdown_output}" == "true" ]; then
-    log_format=$markdown_git_log_format
-else
-    log_format=$git_log_format
-fi
-
 if [ $all_tags = 0 ]; then
     # No tags, exit.
     echo "Repository contains no tags. Please make a tag first."
@@ -20,7 +14,7 @@ elif [ $all_tags = 1 ]; then
     echo "Fetching commits since first commit."
     # We have first tag, fetch since first commit (ie. don't specify previous tag)
     
-    changelog="$(git log --pretty=format:"$log_format") --date=format:"%Y-%m-%d %H:%M:%S""
+    changelog="$(git log --pretty=format:"$git_log_format") --date=format:"%Y-%m-%d %H:%M:%S""
 else 
     echo "Fetching commits since last tag."
 
@@ -29,7 +23,7 @@ else
     previous_tag="$(git describe --abbrev=0 --tags $(git rev-list --tags --skip=1 --max-count=1))"
 
     # Get commit messages since previous tag
-    changelog="$(git log --pretty=format:"$log_format" --date=format:"%Y-%m-%d %H:%M:%S" $latest_tag...$previous_tag)"
+    changelog="$(git log --pretty=format:"$git_log_format" --date=format:"%Y-%m-%d %H:%M:%S" $latest_tag...$previous_tag)"
 fi
 
 # Add branch info

--- a/step.sh
+++ b/step.sh
@@ -6,6 +6,12 @@ set -e
 # Read all tags, separate them into an array
 all_tags=`git tag -l | wc -l`
 
+if [ -n "${markdown_output}" -a "${markdown_output}" == "true" ]; then
+    is_markdown="true"
+else
+    is_markdown="false"
+fi
+
 if [ $all_tags = 0 ]; then
     # No tags, exit.
     echo "Repository contains no tags. Please make a tag first."
@@ -14,7 +20,7 @@ elif [ $all_tags = 1 ]; then
     echo "Fetching commits since first commit."
     # We have first tag, fetch since first commit (ie. don't specify previous tag)
     
-    if [ -n "${markdown_output}" -a "${markdown_output}" == "true" ]; then
+    if [ $is_markdown == "true" ]; then
         changelog="$(git log --pretty=format:" - %s (%cd) _<%ce>_") --date=format:"%Y-%m-%d %H:%M:%S""
     else
         changelog="$(git log --pretty=format:" - %s (%cd) _<%ce>_") --date=format:"%Y-%m-%d %H:%M:%S""
@@ -27,7 +33,7 @@ else
     previous_tag="$(git describe --abbrev=0 --tags $(git rev-list --tags --skip=1 --max-count=1))"
 
     # Get commit messages since previous tag
-    if [ -n "${markdown_output}" -a "${markdown_output}" == "true" ]; then
+    if [ $is_markdown == "true" ]; then
         changelog="$(git log --pretty=format:" - %s (%cd) _<%ce>_" --date=format:"%Y-%m-%d %H:%M:%S" $latest_tag...$previous_tag)"    
     else
         changelog="$(git log --pretty=format:"%s  (%cd) _<%ce>_" --date=format:"%Y-%m-%d %H:%M:%S" $latest_tag...$previous_tag)"    

--- a/step.sh
+++ b/step.sh
@@ -7,9 +7,9 @@ set -e
 all_tags=`git tag -l | wc -l`
 
 if [ -n "${markdown_output}" -a "${markdown_output}" == "true" ]; then
-    is_markdown="true"
+    log_format=$markdown_git_log_format
 else
-    is_markdown="false"
+    log_format=$git_log_format
 fi
 
 if [ $all_tags = 0 ]; then
@@ -20,11 +20,7 @@ elif [ $all_tags = 1 ]; then
     echo "Fetching commits since first commit."
     # We have first tag, fetch since first commit (ie. don't specify previous tag)
     
-    if [ $is_markdown == "true" ]; then
-        changelog="$(git log --pretty=format:" - %s (%cd) _<%ce>_") --date=format:"%Y-%m-%d %H:%M:%S""
-    else
-        changelog="$(git log --pretty=format:" - %s (%cd) _<%ce>_") --date=format:"%Y-%m-%d %H:%M:%S""
-    fi
+    changelog="$(git log --pretty=format:"$log_format") --date=format:"%Y-%m-%d %H:%M:%S""
 else 
     echo "Fetching commits since last tag."
 
@@ -33,11 +29,7 @@ else
     previous_tag="$(git describe --abbrev=0 --tags $(git rev-list --tags --skip=1 --max-count=1))"
 
     # Get commit messages since previous tag
-    if [ $is_markdown == "true" ]; then
-        changelog="$(git log --pretty=format:" - %s (%cd) _<%ce>_" --date=format:"%Y-%m-%d %H:%M:%S" $latest_tag...$previous_tag)"    
-    else
-        changelog="$(git log --pretty=format:"%s  (%cd) _<%ce>_" --date=format:"%Y-%m-%d %H:%M:%S" $latest_tag...$previous_tag)"    
-    fi
+    changelog="$(git log --pretty=format:"$log_format" --date=format:"%Y-%m-%d %H:%M:%S" $latest_tag...$previous_tag)"
 fi
 
 # Add branch info

--- a/step.yml
+++ b/step.yml
@@ -22,7 +22,7 @@ run_if: true
 inputs:
 - git_log_format: "%s  (%cd) _<%ce>_"
   opts:
-    title: `git log` format string to use
+    title: git log format string to use
     is_expand: false
     is_required: false
 outputs:

--- a/step.yml
+++ b/step.yml
@@ -20,19 +20,6 @@ deps:
   - name: git
 run_if: true
 inputs:
-- markdown_output: "yes"
-  opts:
-    is_expand: false
-    is_required: true
-    title: Format the changelog as markdown
-    value_options:
-    - "yes"
-    - "no"
-- markdown_git_log_format: " - %s (%cd) _<%ce>_"
-  opts:
-    title: `git log` format string to use when outputting as markdown
-    is_expand: false
-    is_required: false
 - git_log_format: "%s  (%cd) _<%ce>_"
   opts:
     title: `git log` format string to use

--- a/step.yml
+++ b/step.yml
@@ -28,6 +28,16 @@ inputs:
     value_options:
     - "yes"
     - "no"
+- markdown_git_log_format: " - %s (%cd) _<%ce>_"
+  opts:
+    title: `git log` format string to use when outputting as markdown
+    is_expand: false
+    is_required: false
+- git_log_format: "%s  (%cd) _<%ce>_"
+  opts:
+    title: `git log` format string to use
+    is_expand: false
+    is_required: false
 outputs:
   - COMMIT_CHANGELOG: ""
     opts:


### PR DESCRIPTION
Currently, the only customization that's exposed for the changelog is to enable "markdown" formatting or not.

I wanted to tweak the format to be slightly less verbose, but found there was no way to do here.

Here in this PR, i'm removing the `is_markdown` boolean config and instead exposing a way to allow users to set the format themselves.

I'm retaining the existing log format as the default.

Thought i'd open this PR in case others found it handy :)